### PR TITLE
feat: footer 컴포넌트 생성

### DIFF
--- a/mcy/src/components/Layout/Layout.jsx
+++ b/mcy/src/components/Layout/Layout.jsx
@@ -8,10 +8,18 @@ const Layout = ({ children }) => {
   return (
     <>
       <Header />
-
+      <ContentWrapper>
+        {children}
+      </ContentWrapper>
       <Footer />
     </>
   );
 };
 
+const ContentWrapper = styled(Stack)`
+height: calc(100dvh - 120px);
+flex-direction: row;
+justify-content: center;
+align-items: center;
+`;
 export default Layout;

--- a/mcy/src/components/Layout/Layout.jsx
+++ b/mcy/src/components/Layout/Layout.jsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/prop-types */
+
+import { Stack, Typography, styled } from "@mui/material";
+import Footer from "./Footer";
+import Header from "./Header";
+
+const Layout = ({ children }) => {
+  return (
+    <>
+      <Header />
+
+      <Footer />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,4 @@
 #root {
-  max-width: 1280px;
-
-
-  
+  width: 100%;
+  height: 100%;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,6 @@
 #root {
   width: 100%;
-  height: 100%;
+  height: 100vh;
+  height: 100dvh;
+  height: -webkit-fill-available;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,3 @@
 #root {
-  width: 100%;
-  height: 100vh;
-  height: 100dvh;
-  height: -webkit-fill-available;
+  
 }

--- a/src/components/Layout/Footer.jsx
+++ b/src/components/Layout/Footer.jsx
@@ -1,5 +1,23 @@
+import { Stack, Typography, styled } from "@mui/material";
+
 const Footer = () => {
-  return <div>Footer</div>;
+  return (
+    <>
+      <FooterWrapper>
+        <Typography fontSize= "12px">MCY</Typography>
+        <Typography fontSize="12px">Copyright 2024. MCY all rights reserved.</Typography>
+      </FooterWrapper>
+    </>
+  );
 };
 
+const FooterWrapper = styled(Stack)`
+  align-items: center;
+  justify-content: center;
+  width:100%;
+  height:70px;
+  position: fixed;
+  bottom:0;
+  background-color:#F4F1E9;
+`;
 export default Footer;

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -26,8 +26,6 @@ const HeaderWrapper = styled(Stack)`
   justify-content: center;
   width: 100%;
   height: 50px;
-  position: fixed;
-  top: 0;
   border-bottom: 1px solid #FEEDCD;
 `;
 

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -20,23 +20,21 @@ const Header = ({ setOpen }) => {
 };
 
 const HeaderWrapper = styled(Stack)`
+  background-color: #FFFFFF;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  width: 100vw;
+  width: 100%;
+  height: 50px;
   position: fixed;
   top: 0;
-  border-bottom: 1px solid #000;
-  padding: 5px;
+  border-bottom: 1px solid #FEEDCD;
 `;
 
 const MenuIconWrapper = styled(Stack)`
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  width: 100vw;
   position: fixed;
-  top: 0;
+  top: 5px;
+  right: 1%;
 `;
 
 const MenuIcons = styled(MenuIcon)`

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 :root {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  height: -webkit-fill-available;
 
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/src/index.css
+++ b/src/index.css
@@ -28,10 +28,9 @@ a:hover {
 body {
   margin: 0;
   height: 100%;
-  /* display: flex; */
-  /* place-items: center; */
   min-width: 320px;
   min-height: 100vh;
+
 }
 
 h1 {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
 
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -27,8 +27,9 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  height: 100%;
+  /* display: flex; */
+  /* place-items: center; */
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## 작업내용
1.  feat: footer 컴포넌트 

2.  fix: header 컴포넌트 코드 수정 
  
+ 문제점 1:  MCY 로고가 정중앙이 아니고 살짝 오른쪽으로 치우쳐져 있었습니다. 
  
+ 문제점 2:  footer 부분을 작업하다 우연히 스크롤을 내리게 됐는데 header 부분의 높이를 잡아주지 않아 
  스크롤을 내릴때 햄버거 메뉴는 아래로 내려가고 로고는 위로 올라가는 것을 확인했고 수정한 후에 
  스크롤을 내릴때 같이 고정 되어 동작하는거 확인했습니다!   
  
+ 문제점 3:  Icon styled 컴포넌트에 불필요한 코드가 많아서 수정했습니다!    
  
+ 변경사항: header 부분에 boder-bottom 색상 변경해주었습니다! 
            

## 고민하거나 궁금한 부분
100vh 단위를 쓰게 되면 모바일에서는 상하단의 바 영역을 반영하지 못하기 때문에
상단 주소창의 윗부분부터 Viewport로 인식하게 되어 스크롤이 발생한다고 하는데 
그럼 단위는 %로 작성해야 될까요?  


## 캡처 또는 영상 (optional)

![풋터 결과](https://github.com/ykss/mcy/assets/97350693/f43751f2-f109-4ece-b84b-7edb3b7245d9)

