### PR TITLE
feat: 생일축하 페이지 제목 컴포넌트 생성

### DIFF
--- a/src/components/Layout/Drawer.jsx
+++ b/src/components/Layout/Drawer.jsx
@@ -3,7 +3,6 @@ import { styled } from "@mui/material";
 import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import DrawerSlide from "@mui/material/Drawer";
-import Button from "@mui/material/Button";
 import List from "@mui/material/List";
 import ListItemText from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
@@ -60,7 +59,6 @@ const Drawer = ({ open, setOpen }) => {
 
   return (
     <>
-      <Button onClick={toggleDrawer(true)}></Button>
       <DrawerSlide open={open} onClose={toggleDrawer(false)} anchor="right">
         {DrawerList}
       </DrawerSlide>

--- a/src/components/Layout/Drawer.jsx
+++ b/src/components/Layout/Drawer.jsx
@@ -13,8 +13,8 @@ import CheckIcon from "@mui/icons-material/Check";
 const Drawer = ({ open, setOpen }) => {
   const Navigate = useNavigate();
 
-  const toggleDrawer = (newOpen) => () => {
-    setOpen(newOpen);
+  const toggleDrawer = () => {
+    setOpen(false);
   };
 
   const handleGoToNews = () => {
@@ -32,7 +32,7 @@ const Drawer = ({ open, setOpen }) => {
   const DrawerList = (
     <Box rol="presentation">
       <DrawerTop>
-        <ExitIcon onClick={toggleDrawer(false)} />
+        <ExitIcon onClick={toggleDrawer} />
       </DrawerTop>
       <List>
         <ListButton>
@@ -59,7 +59,7 @@ const Drawer = ({ open, setOpen }) => {
 
   return (
     <>
-      <DrawerSlide open={open} onClose={toggleDrawer(false)} anchor="right">
+      <DrawerSlide open={open} onClose={toggleDrawer} anchor="right">
         {DrawerList}
       </DrawerSlide>
     </>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -4,7 +4,12 @@ import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
 
-const Header = ({ setOpen }) => {
+const Header = ({ setIsDrawerOpen }) => {
+  
+  const handleDrawerOpen = (newOpen) => () => {
+    setIsDrawerOpen(newOpen);
+  };
+  
   return (
     <>
       <HeaderWrapper>
@@ -12,7 +17,7 @@ const Header = ({ setOpen }) => {
           <Typography fontWeight="bold">MCY</Typography>
         </LogoWrapper>
         <MenuIconWrapper>
-          <IconButton onClick={() => setOpen(true)}>
+          <IconButton onClick={handleDrawerOpen(true)}>
             <MenuIcons />
           </IconButton>
         </MenuIconWrapper>
@@ -25,13 +30,13 @@ const LogoWrapper = styled(Stack)`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  width: 100vw; 
+  width: 100vw;
 `;
 
 const MenuIconWrapper = styled(Stack)`
   position: absolute;
   top: 5px;
-  right: 1%; 
+  right: 1%;
 `;
 
 const MenuIcons = styled(MenuIcon)`

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -6,8 +6,8 @@ import MenuIcon from "@mui/icons-material/Menu";
 
 const Header = ({ setIsDrawerOpen }) => {
   
-  const handleDrawerOpen = (newOpen) => () => {
-    setIsDrawerOpen(newOpen);
+  const handleDrawerOpen = () => {
+    setIsDrawerOpen(true);
   };
   
   return (
@@ -17,7 +17,7 @@ const Header = ({ setIsDrawerOpen }) => {
           <Typography fontWeight="bold">MCY</Typography>
         </LogoWrapper>
         <MenuIconWrapper>
-          <IconButton onClick={handleDrawerOpen(true)}>
+          <IconButton onClick={handleDrawerOpen}>
             <MenuIcons />
           </IconButton>
         </MenuIconWrapper>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -8,35 +8,43 @@ const Header = ({ setOpen }) => {
   return (
     <>
       <HeaderWrapper>
-        <Typography fontWeight="bold">MCY</Typography>
+        <LogoWrapper>
+          <Typography fontWeight="bold">MCY</Typography>
+        </LogoWrapper>
+        <MenuIconWrapper>
+          <IconButton onClick={() => setOpen(true)}>
+            <MenuIcons />
+          </IconButton>
+        </MenuIconWrapper>
       </HeaderWrapper>
-      <MenuIconWrapper>
-        <IconButton onClick={() => setOpen(true)}>
-          <MenuIcons />
-        </IconButton>
-      </MenuIconWrapper>
     </>
   );
 };
 
-const HeaderWrapper = styled(Stack)`
-  background-color: #FFFFFF;
+const LogoWrapper = styled(Stack)`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 50px;
-  border-bottom: 1px solid #FEEDCD;
+  width: 100vw; 
 `;
 
 const MenuIconWrapper = styled(Stack)`
-  position: fixed;
+  position: absolute;
   top: 5px;
-  right: 1%;
+  right: 1%; 
 `;
 
 const MenuIcons = styled(MenuIcon)`
   color: #000;
+`;
+
+const HeaderWrapper = styled(Stack)`
+  background-color: #ffffff;
+  flex-direction: row;
+  align-items: center;
+  height: 50px;
+  border-bottom: 1px solid #feedcd;
+  width: 100vw;
 `;
 
 export default Header;

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,16 +1,26 @@
+import { Stack, styled } from "@mui/material";
 import React from "react";
 import Drawer from "./Drawer";
 import Header from "./Header";
+import Footer from "./Footer";
 
-const Layout = () => {
-  const [open, setOpen] = React.useState(false);
+const Layout = ({ children }) => {
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
 
   return (
     <div>
-      <Header setOpen={setOpen} />
-      <Drawer open={open} setOpen={setOpen} />
+      <Header setOpen={setIsDrawerOpen} />
+      <Drawer open={isDrawerOpen} setOpen={setIsDrawerOpen} />
+      <ContentWrapper>{children}</ContentWrapper>
+      <Footer />
     </div>
   );
 };
-
+const ContentWrapper = styled(Stack)`
+  width: 100vw;
+  height: calc(100dvh - 120px);
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
 export default Layout;

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -9,7 +9,7 @@ const Layout = ({ children }) => {
 
   return (
     <div>
-      <Header setOpen={setIsDrawerOpen} />
+      <Header setIsDrawerOpen={setIsDrawerOpen} />
       <Drawer open={isDrawerOpen} setOpen={setIsDrawerOpen} />
       <ContentWrapper>{children}</ContentWrapper>
       <Footer />

--- a/src/pages/BirthDay.jsx
+++ b/src/pages/BirthDay.jsx
@@ -5,12 +5,10 @@ import { styled, Stack, Typography } from "@mui/material";
 const BirthDay = () => {
   return (
     <Layout>
-      <BirthdayComponentWrapper>
+      <BirthdayWrapper>
         <TitleWrapper>
-          <Title>
-            <CakeIcon sx={{ fontSize: 40 }} />
-            <Typography fontSize="20px">생일!</Typography>
-          </Title>
+          <CakeIcon sx={{ fontSize: 40 }} />
+          <Typography fontSize="20px">생일!</Typography>
         </TitleWrapper>
         <MonthChip>
           <Typography>MonthChip</Typography>
@@ -18,26 +16,23 @@ const BirthDay = () => {
         <BirthdayList>
           <Typography>생일자 명단</Typography>
         </BirthdayList>
-      </BirthdayComponentWrapper>
+      </BirthdayWrapper>
     </Layout>
   );
 };
 
-const BirthdayComponentWrapper = styled(Stack)`
+const BirthdayWrapper = styled(Stack)`
   height: calc(100dvh - 120px);
-  width:100vw;
+  width: 100vw;
 `;
 const TitleWrapper = styled(Stack)`
   flex-direction: row;
-  align-items: center;
-  height: 15%;
-`;
-const Title = styled(Stack)`
-  width: 35%;
-  flex-direction: row;
   align-items: flex-end;
+  width: 35%;
+  height: 10  %;
   justify-content: space-evenly;
 `;
+
 const MonthChip = styled(Stack)`
   height: 15%;
   width: 100%;

--- a/src/pages/BirthDay.jsx
+++ b/src/pages/BirthDay.jsx
@@ -1,11 +1,53 @@
 import Layout from "../components/Layout/Layout";
+import CakeIcon from "@mui/icons-material/Cake";
+import { styled, Stack, Typography } from "@mui/material";
 
 const BirthDay = () => {
   return (
     <Layout>
-      <div>BirthDay</div>
+      <BirthdayComponentWrapper>
+        <TitleWrapper>
+          <Title>
+            <CakeIcon sx={{ fontSize: 40 }} />
+            <Typography fontSize="20px">생일!</Typography>
+          </Title>
+        </TitleWrapper>
+        <MonthChip>
+          <Typography>MonthChip</Typography>
+        </MonthChip>
+        <BirthdayList>
+          <Typography>생일자 명단</Typography>
+        </BirthdayList>
+      </BirthdayComponentWrapper>
     </Layout>
   );
 };
 
+const BirthdayComponentWrapper = styled(Stack)`
+  height: calc(100dvh - 120px);
+  width:100vw;
+`;
+const TitleWrapper = styled(Stack)`
+  flex-direction: row;
+  align-items: center;
+  height: 15%;
+`;
+const Title = styled(Stack)`
+  width: 35%;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-evenly;
+`;
+const MonthChip = styled(Stack)`
+  height: 15%;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+const BirthdayList = styled(Stack)`
+  height: 70%;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+`;
 export default BirthDay;

--- a/src/pages/BirthDay.jsx
+++ b/src/pages/BirthDay.jsx
@@ -1,6 +1,7 @@
-import Layout from "../components/Layout/Layout";
 import CakeIcon from "@mui/icons-material/Cake";
 import { styled, Stack, Typography } from "@mui/material";
+
+import Layout from "../components/Layout/Layout";
 
 const BirthDay = () => {
   return (
@@ -27,10 +28,10 @@ const BirthdayWrapper = styled(Stack)`
 `;
 const TitleWrapper = styled(Stack)`
   flex-direction: row;
-  align-items: flex-end;
-  width: 35%;
-  height: 10  %;
-  justify-content: space-evenly;
+  align-items: center;
+  height: 10%;
+  gap: 15px;
+  padding: 0 10px;
 `;
 
 const MonthChip = styled(Stack)`


### PR DESCRIPTION
## 작업내용
1. feat: 생일축하 페이지 제목 컴포넌트 생성
+ 아이콘 및 생일 텍스트 생성
+ MonthChip, BirthDay 레이아웃 구성
2. fix: Header 햄버거 아이콘 에러 해결
+ position을 fixed -> absolute로 변경
3. fix: Drawer.jsx 불필요 버튼 삭제
4. fix: Layout.jsx 변수 명칭 변경

## 고민하거나 궁금한 부분

-

## 캡처 또는 영상 (optional)
![생일페이지 결과](https://github.com/ykss/mcy/assets/97350693/6f88256b-13a7-4668-924b-774e978a05a6)
