### PR TITLE
pwa 설정에서 오타 수정, 사파리 브라우저 생일자 명단 나오지 않는 현상 수정, pwabuilde-sw.js 파일 경로 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             console.log("Service worker registration succeeded:", registration)
           })
           .catch(err => {
-            console.log("Service worker registration failed:", error)
+            console.log("Service worker registration failed:", err)
           })
       } else {
         console.log("Service workers are not supported.")

--- a/pwabuilder-sw.js
+++ b/pwabuilder-sw.js
@@ -1,11 +1,7 @@
-// This is the "Offline page" service worker
-
 importScripts("https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js")
 
 const CACHE = "pwabuilder-page"
-
-// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";
-const offlineFallbackPage = "offline.html"
+const offlineFallbackPage = "/offline.html"
 
 self.addEventListener("message", event => {
   if (event.data && event.data.type === "SKIP_WAITING") {

--- a/src/pages/BirthDay.jsx
+++ b/src/pages/BirthDay.jsx
@@ -37,7 +37,11 @@ const BirthDay = () => {
 
   // Chip 아이디 값이 변경될때마다 필터를 통해 해당 월의 데이터만 추출
   useEffect(() => {
-    const filteredData = birthDayData.filter(item => Number(dayjs(item.date).format("M")) === monthChipId).sort((a, b) => Number(dayjs(a.date).format("DD")) - Number(dayjs(b.date).format("DD")))
+    const filteredData = birthDayData.filter(item => {
+      const date = dayjs(item.date, "MM-DD") // 날짜 형식에 맞게 수정
+      const month = date.month() + 1 // dayjs는 0부터 시작하므로 +1
+      return month === monthChipId
+    })
     setSelectedData(filteredData)
   }, [monthChipId, birthDayData])
 
@@ -64,7 +68,7 @@ const BirthDay = () => {
             <ListWrapper>
               {selectedData.map(item => (
                 <List key={item.name}>
-                  <Typography fontSize={14}>{dayjs(item.date).format("DD")}일</Typography>
+                  <Typography fontSize={14}>{item.date.substring(3, 5)}일</Typography>
                   <Typography fontSize={14}>{item.name}</Typography>
                 </List>
               ))}


### PR DESCRIPTION
## 작업내용

- fix. pwa 설정에서 오타 수정(error -> 받은 매개변수 err)
- fix. pwabuilder-sw.js파일 경로 오류 수정
- fix. 사파리 브라우저 생일자 명단 나오지 않는 현상 수정

## 고민하거나 궁금한 부분

- 생일 로직중에 필터링 과정에서 잘못되어서 사파리에서 생일자 명단이 나오지 않았었는데 필터 로직을 잘못 사용하면 특정 브라우저에서 데이터를 못 불러오는 경우도 발생되나요? -> 필터링 문제인줄 알았는데 수정 후에 ios 날짜 포맷이 달라서 안 된거라고 알게 되어서 블로그 정독했습니다!

## 캡처 또는 영상 (optional)

**chrome**

https://github.com/user-attachments/assets/300b9df8-9fc3-4fcb-afcf-b0b6d376427d

**safari**

https://github.com/user-attachments/assets/a601e91c-92ac-4c35-8c26-226f4f5e8048


